### PR TITLE
PSUseSyntacticallyCorrectExamples fails when passed a method in a class

### DIFF
--- a/Indented.CodingConventions/public/rules/PSUseSyntacticallyCorrectExamples.ps1
+++ b/Indented.CodingConventions/public/rules/PSUseSyntacticallyCorrectExamples.ps1
@@ -60,6 +60,10 @@ filter PSUseSyntacticallyCorrectExamples {
         [FunctionDefinitionAst]$ast
     )
 
+    if ($ast.Parent.Parent.IsClass) {
+        return
+    }
+    
     $definition = [ScriptBlock]::Create($ast.Extent.ToString())
     $functionInfo = Get-FunctionInfo -ScriptBlock $definition
 

--- a/Indented.CodingConventions/tests/unit/rules/PSUseSyntacticallyCorrectExamples.tests.ps1
+++ b/Indented.CodingConventions/tests/unit/rules/PSUseSyntacticallyCorrectExamples.tests.ps1
@@ -170,6 +170,18 @@ InModuleScope Indented.CodingConventions {
 
                 Invoke-CodingConventionRule -ScriptBlock $script @ruleName | Should -BeNullOrEmpty
             }
+
+            It 'parent is a class, returns null' {
+                $script = {
+                    class name {
+                        [void] method () {
+
+                        }
+                    }
+                }
+
+                Invoke-CodingConventionRule -ScriptBlock $script @ruleName | Should -BeNullOrEmpty
+            }
         }
     }
 }


### PR DESCRIPTION
Methods are seen as FunctionDefinitionAst objects so need to check the
parent of it's parent to see if it's a class and return null if so.